### PR TITLE
use boost::shared_ptr instead of raw pointers for more condense code and...

### DIFF
--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -89,10 +89,9 @@ ImuDisplay::~ImuDisplay()
 void ImuDisplay::reset()
 {
   MFDClass::reset();
-  for( size_t i = 0; i < visuals_.size(); i++ )
-  {
-    visuals_[i].reset();
-  }
+  size_t size = visuals_.size();
+  visuals_.clear();
+  visuals_.set_capacity(size);
 }
 
 // Set the current color and alpha values for each visual.
@@ -103,39 +102,14 @@ void ImuDisplay::updateColorAndAlpha()
 
   for( size_t i = 0; i < visuals_.size(); i++ )
   {
-    if( visuals_[ i ] )
-    {
-      visuals_[ i ]->setColor( color.r, color.g, color.b, alpha );
-    }
+    visuals_[ i ]->setColor( color.r, color.g, color.b, alpha );
   }
 }
 
 // Set the number of past visuals to show.
 void ImuDisplay::updateHistoryLength()
 {
-  int new_length = history_length_property_->getInt();
-
-  // Create a new array of visual pointers, all NULL.
-  std::vector<boost::shared_ptr<ImuVisual> > new_visuals( new_length );
-
-  // Copy the contents from the old array to the new.
-  // (Number to copy is the minimum of the 2 vector lengths).
-  size_t copy_len =
-    (new_visuals.size() > visuals_.size()) ?
-    visuals_.size() : new_visuals.size();
-  for( size_t i = 0; i < copy_len; i++ )
-  {
-    int new_index = (messages_received_ - i) % new_visuals.size();
-    int old_index = (messages_received_ - i) % visuals_.size();
-    new_visuals[ new_index ] = visuals_[ old_index ];
-  }
-
-  // We don't need to create any new visuals here, they are created as
-  // needed when messages are received.
-
-  // Put the new vector into the member variable version and let the
-  // old one go out of scope.
-  visuals_.swap( new_visuals );
+  visuals_.set_capacity(history_length_property_->getInt());
 }
 
 // This is our callback to handle an incoming message.
@@ -155,15 +129,12 @@ void ImuDisplay::processMessage( const sensor_msgs::Imu::ConstPtr& msg )
     return;
   }
 
-  int history_length = history_length_property_->getInt();
-
   // We are keeping a circular buffer of visual pointers.  This gets
   // the next one, or creates and stores it if it was missing.
-  boost::shared_ptr<ImuVisual> visual = visuals_[ messages_received_ % history_length ];
+  boost::shared_ptr<ImuVisual> visual = visuals_.front();
   if( !visual )
   {
     visual.reset(new ImuVisual( context_->getSceneManager(), scene_node_ ));
-    visuals_[ messages_received_ % history_length ] = visual;
   }
 
   // Now set or update the contents of the chosen visual.
@@ -174,6 +145,9 @@ void ImuDisplay::processMessage( const sensor_msgs::Imu::ConstPtr& msg )
   float alpha = alpha_property_->getFloat();
   Ogre::ColourValue color = color_property_->getOgreColor();
   visual->setColor( color.r, color.g, color.b, alpha );
+
+  // And send it to the end of the circular buffer
+  visuals_.push_back(visual);
 }
 
 } // end namespace rviz_plugin_tutorials

--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -50,17 +50,17 @@ namespace rviz_plugin_tutorials
 // constructor the parameters it needs to fully initialize.
 ImuDisplay::ImuDisplay()
 {
-  color_property_.reset(new rviz::ColorProperty( "Color", QColor( 204, 51, 204 ),
+  color_property_ = new rviz::ColorProperty( "Color", QColor( 204, 51, 204 ),
                                              "Color to draw the acceleration arrows.",
-                                             this, SLOT( updateColorAndAlpha() )));
+                                             this, SLOT( updateColorAndAlpha() ));
 
-  alpha_property_.reset(new rviz::FloatProperty( "Alpha", 1.0,
+  alpha_property_ = new rviz::FloatProperty( "Alpha", 1.0,
                                              "0 is fully transparent, 1.0 is fully opaque.",
-                                             this, SLOT( updateColorAndAlpha() )));
+                                             this, SLOT( updateColorAndAlpha() ));
 
-  history_length_property_.reset(new rviz::IntProperty( "History Length", 1,
+  history_length_property_ = new rviz::IntProperty( "History Length", 1,
                                                     "Number of prior measurements to display.",
-                                                    this, SLOT( updateHistoryLength() )));
+                                                    this, SLOT( updateHistoryLength() ));
   history_length_property_->setMin( 1 );
   history_length_property_->setMax( 100000 );
 }

--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -89,9 +89,7 @@ ImuDisplay::~ImuDisplay()
 void ImuDisplay::reset()
 {
   MFDClass::reset();
-  size_t size = visuals_.size();
   visuals_.clear();
-  visuals_.set_capacity(size);
 }
 
 // Set the current color and alpha values for each visual.

--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -130,7 +130,7 @@ void ImuDisplay::processMessage( const sensor_msgs::Imu::ConstPtr& msg )
   // We are keeping a circular buffer of visual pointers.  This gets
   // the next one, or creates and stores it if the buffer is not full
   boost::shared_ptr<ImuVisual> visual;
-  if( visuals_.size() == visuals_.capacity() )
+  if( visuals_.full() )
   {
     visual = visuals_.front();
   }

--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -128,9 +128,13 @@ void ImuDisplay::processMessage( const sensor_msgs::Imu::ConstPtr& msg )
   }
 
   // We are keeping a circular buffer of visual pointers.  This gets
-  // the next one, or creates and stores it if it was missing.
-  boost::shared_ptr<ImuVisual> visual = visuals_.front();
-  if( !visual )
+  // the next one, or creates and stores it if the buffer is not full
+  boost::shared_ptr<ImuVisual> visual;
+  if( visuals_.size() == visuals_.capacity() )
+  {
+    visual = visuals_.front();
+  }
+  else
   {
     visual.reset(new ImuVisual( context_->getSceneManager(), scene_node_ ));
   }

--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -107,7 +107,7 @@ void ImuDisplay::updateColorAndAlpha()
 // Set the number of past visuals to show.
 void ImuDisplay::updateHistoryLength()
 {
-  visuals_.set_capacity(history_length_property_->getInt());
+  visuals_.rset_capacity(history_length_property_->getInt());
 }
 
 // This is our callback to handle an incoming message.

--- a/rviz_plugin_tutorials/src/imu_display.h
+++ b/rviz_plugin_tutorials/src/imu_display.h
@@ -101,12 +101,12 @@ private:
   // Storage for the list of visuals.  This display supports an
   // adjustable history length, so we need one visual per history
   // item.
-  std::vector<ImuVisual*> visuals_;
+  std::vector<boost::shared_ptr<ImuVisual> > visuals_;
 
   // User-editable property variables.
-  rviz::ColorProperty* color_property_;
-  rviz::FloatProperty* alpha_property_;
-  rviz::IntProperty* history_length_property_;
+  boost::shared_ptr<rviz::ColorProperty> color_property_;
+  boost::shared_ptr<rviz::FloatProperty> alpha_property_;
+  boost::shared_ptr<rviz::IntProperty> history_length_property_;
 };
 // END_TUTORIAL
 

--- a/rviz_plugin_tutorials/src/imu_display.h
+++ b/rviz_plugin_tutorials/src/imu_display.h
@@ -100,9 +100,8 @@ private Q_SLOTS:
 private:
   void processMessage( const sensor_msgs::Imu::ConstPtr& msg );
 
-  // Storage for the list of visuals.  This display supports an
-  // adjustable history length, so we need one visual per history
-  // item.
+  // Storage for the list of visuals.  It is a circular buffer where
+  // data gets popped from the front (oldest) and pushed to the back (newest)
   boost::circular_buffer<boost::shared_ptr<ImuVisual> > visuals_;
 
   // User-editable property variables.

--- a/rviz_plugin_tutorials/src/imu_display.h
+++ b/rviz_plugin_tutorials/src/imu_display.h
@@ -30,6 +30,8 @@
 #ifndef IMU_DISPLAY_H
 #define IMU_DISPLAY_H
 
+#include <boost/circular_buffer.hpp>
+
 #include <sensor_msgs/Imu.h>
 #include <rviz/message_filter_display.h>
 
@@ -101,7 +103,7 @@ private:
   // Storage for the list of visuals.  This display supports an
   // adjustable history length, so we need one visual per history
   // item.
-  std::vector<boost::shared_ptr<ImuVisual> > visuals_;
+  boost::circular_buffer<boost::shared_ptr<ImuVisual> > visuals_;
 
   // User-editable property variables.
   boost::shared_ptr<rviz::ColorProperty> color_property_;

--- a/rviz_plugin_tutorials/src/imu_display.h
+++ b/rviz_plugin_tutorials/src/imu_display.h
@@ -105,9 +105,9 @@ private:
   boost::circular_buffer<boost::shared_ptr<ImuVisual> > visuals_;
 
   // User-editable property variables.
-  boost::shared_ptr<rviz::ColorProperty> color_property_;
-  boost::shared_ptr<rviz::FloatProperty> alpha_property_;
-  boost::shared_ptr<rviz::IntProperty> history_length_property_;
+  rviz::ColorProperty* color_property_;
+  rviz::FloatProperty* alpha_property_;
+  rviz::IntProperty* history_length_property_;
 };
 // END_TUTORIAL
 

--- a/rviz_plugin_tutorials/src/imu_visual.cpp
+++ b/rviz_plugin_tutorials/src/imu_visual.cpp
@@ -54,14 +54,11 @@ ImuVisual::ImuVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent
 
   // We create the arrow object within the frame node so that we can
   // set its position and direction relative to its header frame.
-  acceleration_arrow_ = new rviz::Arrow( scene_manager_, frame_node_ );
+  acceleration_arrow_.reset(new rviz::Arrow( scene_manager_, frame_node_ ));
 }
 
 ImuVisual::~ImuVisual()
 {
-  // Delete the arrow to make it disappear.
-  delete acceleration_arrow_;
-
   // Destroy the frame node since we don't need it anymore.
   scene_manager_->destroySceneNode( frame_node_ );
 }

--- a/rviz_plugin_tutorials/src/imu_visual.h
+++ b/rviz_plugin_tutorials/src/imu_visual.h
@@ -80,7 +80,7 @@ public:
 
 private:
   // The object implementing the actual arrow shape
-  rviz::Arrow* acceleration_arrow_;
+  boost::shared_ptr<rviz::Arrow> acceleration_arrow_;
 
   // A SceneNode whose pose is set to match the coordinate frame of
   // the Imu message header.


### PR DESCRIPTION
... to fix a memory leak
