### PR TITLE
librviz_tutorial: fixed “ld: cannot find -ldefault_plugin” build error

### DIFF
--- a/librviz_tutorial/CMakeLists.txt
+++ b/librviz_tutorial/CMakeLists.txt
@@ -38,5 +38,5 @@ add_executable(myviz ${SOURCE_FILES})
 ## Link the myviz executable with whatever Qt libraries have been defined by
 ## the ``find_package(Qt4 ...)`` line above, and with whatever libraries
 ## catkin has included.
-target_link_libraries(myviz ${QT_LIBRARIES} default_plugin ${catkin_LIBRARIES})
+target_link_libraries(myviz ${QT_LIBRARIES} ${catkin_LIBRARIES})
 ## END_TUTORIAL


### PR DESCRIPTION
A fedora 20 _desktop_ build failed at librviz_tutorial:

```
./src/catkin/bin/catkin_make_isolated --install
…
==> Processing catkin package: 'librviz_tutorial'
==> Building with env: '/tmp/ros-catkin-workspace/install_isolated/env.sh'
Makefile exists, skipping explicit cmake invocation...
==> make cmake_check_build_system in '/tmp/ros-catkin-workspace/build_isolated/librviz_tutorial'
==> make -j4 -l4 in '/tmp/ros-catkin-workspace/build_isolated/librviz_tutorial'
Linking CXX executable "/tmp/ros-catkin-workspace/devel_isolated/librviz_tutorial/lib/librviz_tutorial/myviz"
/usr/bin/ld: cannot find -ldefault_plugin
collect2: error: ld returned 1 exit status
```

The build command for myviz caused the failure. Note how it tries to link a libdefault_plugin as a system library (not installed in the system’s library paths), as well as the catkin workspace’s version. 

> `/usr/lib64/ccache/c++   -O3 -DNDEBUG    CMakeFiles/myviz.dir/src/myviz.cpp.o CMakeFiles/myviz.dir/src/main.cpp.o CMakeFiles/myviz.dir/src/moc_myviz.cxx.o  -o "/tmp/ros-catkin-workspace/devel_isolated/librviz_tutorial/lib/librviz_tutorial/myviz" -rdynamic -lQtGui -lQtCore -ldefault_plugin "/tmp/ros-catkin-workspace/install_isolated/lib/librviz.so" "/tmp/ros-catkin-workspace/install_isolated/lib/libdefault_plugin.so"` …

Removing the explicit default_plugin from target_link_libraries prevents this problem.
