### PR TITLE
Check number of subscribers before publishing marker

### DIFF
--- a/visualization_marker_tutorials/src/basic_shapes.cpp
+++ b/visualization_marker_tutorials/src/basic_shapes.cpp
@@ -105,6 +105,15 @@ int main( int argc, char** argv )
 
     // Publish the marker
 // %Tag(PUBLISH)%
+    while (marker_pub.getNumSubscribers() < 1)
+    {
+      if (!ros::ok())
+      {
+        return 0;
+      }
+      ROS_WARN_ONCE("Please create a subscriber to the marker");
+      sleep(1);
+    }
     marker_pub.publish(marker);
 // %EndTag(PUBLISH)%
 


### PR DESCRIPTION
This checks whether a node has subscribed to the marker topic.
The marker is not published until someone subscribes.

Related [answers.ros.org](http://answers.ros.org/question/199299/why-do-i-need-to-enter-a-loop-to-display-a-marker/) topic.
