### PR TITLE
Add Q_MOC_RUN guard for newer boost

### DIFF
--- a/rviz_plugin_tutorials/src/imu_display.h
+++ b/rviz_plugin_tutorials/src/imu_display.h
@@ -30,7 +30,9 @@
 #ifndef IMU_DISPLAY_H
 #define IMU_DISPLAY_H
 
+#ifndef Q_MOC_RUN
 #include <boost/circular_buffer.hpp>
+#endif
 
 #include <sensor_msgs/Imu.h>
 #include <rviz/message_filter_display.h>


### PR DESCRIPTION
same reason to https://github.com/ros-visualization/rviz/pull/826

It's required to build rqt_plugins_tutorials on os x Yosemite.
