### PR TITLE
Update simple_marker.cpp

### DIFF
--- a/interactive_marker_tutorials/src/simple_marker.cpp
+++ b/interactive_marker_tutorials/src/simple_marker.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv)
   // create an interactive marker for our server
   visualization_msgs::InteractiveMarker int_marker;
   int_marker.header.frame_id = "/base_link";
+  int_marker.header.stamp=ros::Time::now();
   int_marker.name = "my_marker";
   int_marker.description = "Simple 1-DOF Control";
 


### PR DESCRIPTION
updated simple_marker.cpp by including the time stamp. without the time stamp the cube does not show up in rviz and reports an error. The error is generated in rviz after adding an interactive marker:

Error getting time of latest transform between /base_link and base_link:  (error code: 1)
