### PR TITLE
fix frame names in cpp tutorials too

### DIFF
--- a/interactive_marker_tutorials/src/cube.cpp
+++ b/interactive_marker_tutorials/src/cube.cpp
@@ -132,7 +132,7 @@ void makeCube( )
       for ( double z=0.0; z<1.0; z+=step )
       {
         InteractiveMarker int_marker;
-        int_marker.header.frame_id = "/base_link";
+        int_marker.header.frame_id = "base_link";
         int_marker.scale = step;
 
         int_marker.pose.position.x = x;

--- a/interactive_marker_tutorials/src/menu.cpp
+++ b/interactive_marker_tutorials/src/menu.cpp
@@ -117,7 +117,7 @@ InteractiveMarkerControl& makeBoxControl( InteractiveMarker &msg )
 InteractiveMarker makeEmptyMarker( bool dummyBox=true )
 {
   InteractiveMarker int_marker;
-  int_marker.header.frame_id = "/base_link";
+  int_marker.header.frame_id = "base_link";
   int_marker.pose.position.y = -3.0 * marker_pos++;;
   int_marker.scale = 1;
 

--- a/interactive_marker_tutorials/src/point_cloud.cpp
+++ b/interactive_marker_tutorials/src/point_cloud.cpp
@@ -86,7 +86,7 @@ vm::InteractiveMarker makeMarker( std::string name, std::string description, int
 {
   // create an interactive marker for our server
   vm::InteractiveMarker int_marker;
-  int_marker.header.frame_id = "/base_link";
+  int_marker.header.frame_id = "base_link";
   int_marker.name = name;
   int_marker.description = description;
 

--- a/interactive_marker_tutorials/src/pong.cpp
+++ b/interactive_marker_tutorials/src/pong.cpp
@@ -273,7 +273,7 @@ private:
   void updateScore()
   {
     InteractiveMarker int_marker;
-    int_marker.header.frame_id = "/base_link";
+    int_marker.header.frame_id = "base_link";
     int_marker.name = "score";
 
     InteractiveMarkerControl control;
@@ -310,7 +310,7 @@ private:
   void makeFieldMarker()
   {
     InteractiveMarker int_marker;
-    int_marker.header.frame_id = "/base_link";
+    int_marker.header.frame_id = "base_link";
     int_marker.name = "field";
 
     InteractiveMarkerControl control;
@@ -355,7 +355,7 @@ private:
   void makePaddleMarkers()
   {
     InteractiveMarker int_marker;
-    int_marker.header.frame_id = "/base_link";
+    int_marker.header.frame_id = "base_link";
 
     // Add a control for moving the paddle
     InteractiveMarkerControl control;
@@ -433,7 +433,7 @@ private:
   void makeBallMarker()
   {
     InteractiveMarker int_marker;
-    int_marker.header.frame_id = "/base_link";
+    int_marker.header.frame_id = "base_link";
 
     InteractiveMarkerControl control;
     control.always_visible = true;

--- a/interactive_marker_tutorials/src/selection.cpp
+++ b/interactive_marker_tutorials/src/selection.cpp
@@ -113,7 +113,7 @@ public:
 	void updateBox( )
 	{
 	  vm::InteractiveMarker msg;
-	  msg.header.frame_id = "/base_link";
+	  msg.header.frame_id = "base_link";
 
 	  vm::InteractiveMarkerControl control;
 	  control.always_visible = false;
@@ -127,7 +127,7 @@ public:
 	{
 	  // create an interactive marker for our server
 	  vm::InteractiveMarker int_marker;
-	  int_marker.header.frame_id = "/base_link";
+	  int_marker.header.frame_id = "base_link";
 	  int_marker.name = name;
 
 	  // create a point cloud marker
@@ -201,7 +201,7 @@ public:
       for ( int sign=-1; sign<=1; sign+=2 )
       {
         vm::InteractiveMarker int_marker;
-        int_marker.header.frame_id = "/base_link";
+        int_marker.header.frame_id = "base_link";
         int_marker.scale = 1.0;
 
         vm::InteractiveMarkerControl control;

--- a/interactive_marker_tutorials/src/simple_marker.cpp
+++ b/interactive_marker_tutorials/src/simple_marker.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
 
   // create an interactive marker for our server
   visualization_msgs::InteractiveMarker int_marker;
-  int_marker.header.frame_id = "/base_link";
+  int_marker.header.frame_id = "base_link";
   int_marker.header.stamp=ros::Time::now();
   int_marker.name = "my_marker";
   int_marker.description = "Simple 1-DOF Control";


### PR DESCRIPTION
Removed leading slash in frame names of interactive markers.
Same fix as in #26, but now for cpp.
Fixes issue #29.
