### PR TITLE
Use ros::Duration for sleep for better cross-platform

### DIFF
--- a/visualization_marker_tutorials/src/basic_shapes.cpp
+++ b/visualization_marker_tutorials/src/basic_shapes.cpp
@@ -112,7 +112,7 @@ int main( int argc, char** argv )
         return 0;
       }
       ROS_WARN_ONCE("Please create a subscriber to the marker");
-      sleep(1);
+      ros::Duration(1.0).sleep();
     }
     marker_pub.publish(marker);
 // %EndTag(PUBLISH)%


### PR DESCRIPTION
Some systems (e.g. Windows) doesn't have POSIX sleep built-in in the runtime library. Use ros::Duration::sleep for better cross-compiling between platforms.