### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/interactive_marker_tutorials/CMakeLists.txt
+++ b/interactive_marker_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(interactive_marker_tutorials)
 
 find_package(catkin REQUIRED COMPONENTS interactive_markers roscpp visualization_msgs tf)

--- a/librviz_tutorial/CMakeLists.txt
+++ b/librviz_tutorial/CMakeLists.txt
@@ -3,7 +3,7 @@
 ## TeleopPanel tutorial and the ImuDisplay tutorial.
 ##
 ## First start with some standard catkin stuff.
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(librviz_tutorial)
 find_package(catkin REQUIRED COMPONENTS rviz roscpp)
 catkin_package()

--- a/rviz_plugin_tutorials/CMakeLists.txt
+++ b/rviz_plugin_tutorials/CMakeLists.txt
@@ -3,7 +3,7 @@
 ## TeleopPanel tutorial and the ImuDisplay tutorial.
 ##
 ## First start with some standard catkin stuff.
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rviz_plugin_tutorials)
 find_package(catkin REQUIRED COMPONENTS rviz)
 catkin_package()

--- a/rviz_python_tutorial/CMakeLists.txt
+++ b/rviz_python_tutorial/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rviz_python_tutorial)
 find_package(catkin REQUIRED COMPONENTS rviz)
 catkin_package()

--- a/visualization_marker_tutorials/CMakeLists.txt
+++ b/visualization_marker_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(visualization_marker_tutorials)
 
 find_package(catkin REQUIRED COMPONENTS roscpp visualization_msgs)

--- a/visualization_tutorials/CMakeLists.txt
+++ b/visualization_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(visualization_tutorials)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Signed-off-by: ahcorde <ahcorde@gmail.com>