### PR TITLE
Use catkin_install_python()

### DIFF
--- a/interactive_marker_tutorials/CMakeLists.txt
+++ b/interactive_marker_tutorials/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(point_cloud
 ## Install ##
 #############
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/basic_controls.py
   scripts/cube.py
   scripts/menu.py

--- a/rviz_plugin_tutorials/CMakeLists.txt
+++ b/rviz_plugin_tutorials/CMakeLists.txt
@@ -80,5 +80,5 @@ install(DIRECTORY media/
 install(DIRECTORY icons/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/icons)
 
-install(PROGRAMS scripts/send_test_msgs.py
+catkin_install_python(PROGRAMS scripts/send_test_msgs.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/rviz_python_tutorial/CMakeLists.txt
+++ b/rviz_python_tutorial/CMakeLists.txt
@@ -9,5 +9,5 @@ install(FILES
   config.myviz
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(PROGRAMS myviz.py
+catkin_install_python(PROGRAMS myviz.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
This uses [catkin_install_python()](http://docs.ros.org/noetic/api/catkin/html/howto/format2/installing_python.html) to install python scripts to make sure the shebang gets rewritten [as described in the Python 3 transition guide](http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs). This should  be safe to merge into `kinetic-devel`.

Required to release into Noetic #58