### PR TITLE
[Noetic] Update RViz import

### DIFF
--- a/rviz_python_tutorial/myviz.py
+++ b/rviz_python_tutorial/myviz.py
@@ -24,7 +24,7 @@ except ImportError:
     pass
 
 ## Finally import the RViz bindings themselves.
-import rviz
+from rviz import bindings as rviz
 
 ## The MyViz class is the main container widget.
 class MyViz( QWidget ):


### PR DESCRIPTION
This updates the import of the rviz bindings [as described here in the Noetic Migration guide](http://wiki.ros.org/noetic/Migration#RViz_Python_API_import). Without this the script fails to find `rviz.VisualizationFrame()`. This change must be merged into a to-be-created `noetic-devel` branch, and not `kinetic-devel`.

I'm currently unable to verify the rest of the script works because I'm unable to launch RViz in a container, but it may just be a problem with my container setup.