### PR TITLE
PlantFlagTool::makeFlag(): reload mesh resource

### DIFF
--- a/rviz_plugin_tutorials/src/plant_flag_tool.cpp
+++ b/rviz_plugin_tutorials/src/plant_flag_tool.cpp
@@ -194,6 +194,12 @@ int PlantFlagTool::processMouseEvent( rviz::ViewportMouseEvent& event )
 // This is a helper function to create a new flag in the Ogre scene and save its scene node in a list.
 void PlantFlagTool::makeFlag( const Ogre::Vector3& position )
 {
+  if( rviz::loadMeshFromResource( flag_resource_ ).isNull() )
+  {
+    ROS_ERROR( "PlantFlagTool: failed to load model resource '%s'.", flag_resource_.c_str() );
+    return;
+  }
+
   Ogre::SceneNode* node = scene_manager_->getRootSceneNode()->createChildSceneNode();
   Ogre::Entity* entity = scene_manager_->createEntity( flag_resource_ );
   node->attachObject( entity );


### PR DESCRIPTION
A Reset also resets the ResourceManager, such that the mesh resource
is not available anymore and createEntity() will fail.

Fixes ros-visualization/rviz#1618

@mabelzhang: Is there a particular reason that you branched off noetic-devel? I don't see any commits since then, which are noetic-only. In the past we use the same branch (kinetic-devel) for kinetic and melodic.
In any case this fix should be forward-ported to the noetic-devel branch as well.