### PR TITLE
[ROS-O] do not forward-declare Ogre types

### DIFF
--- a/interactive_marker_tutorials/src/pong.cpp
+++ b/interactive_marker_tutorials/src/pong.cpp
@@ -388,13 +388,13 @@ private:
     int_marker.name = "paddle0";
     int_marker.pose.position.x = -PLAYER_X;
     server_.insert( int_marker );
-    server_.setCallback( int_marker.name, boost::bind( &PongGame::processPaddleFeedback, this, 0, _1 ) );
+    server_.setCallback( int_marker.name, [this](auto feedback){ processPaddleFeedback(0, feedback); } );
 
     // Control for player 2
     int_marker.name = "paddle1";
     int_marker.pose.position.x = PLAYER_X;
     server_.insert( int_marker );
-    server_.setCallback( int_marker.name, boost::bind( &PongGame::processPaddleFeedback, this, 1, _1 ) );
+    server_.setCallback( int_marker.name, [this](auto feedback){ processPaddleFeedback(1, feedback); } );
 
     // Make display markers
     marker.scale.x = BORDER_SIZE;

--- a/interactive_marker_tutorials/src/selection.cpp
+++ b/interactive_marker_tutorials/src/selection.cpp
@@ -246,7 +246,7 @@ public:
         interactive_markers::makeArrow( int_marker, control, 0.5 * sign );
 
         int_marker.controls.push_back( control );
-        server_->insert( int_marker, boost::bind( &PointCouldSelector::processAxisFeedback, this, _1 ) );
+        server_->insert( int_marker, [this](auto feedback){ processAxisFeedback(feedback); } );
       }
     }
   }

--- a/rviz_plugin_tutorials/src/imu_visual.h
+++ b/rviz_plugin_tutorials/src/imu_visual.h
@@ -31,12 +31,7 @@
 #define IMU_VISUAL_H
 
 #include <sensor_msgs/Imu.h>
-
-namespace Ogre
-{
-class Vector3;
-class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/rviz_plugin_tutorials/src/plant_flag_tool.h
+++ b/rviz_plugin_tutorials/src/plant_flag_tool.h
@@ -30,12 +30,7 @@
 #define PLANT_FLAG_TOOL_H
 
 #include <rviz/tool.h>
-
-namespace Ogre
-{
-class SceneNode;
-class Vector3;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {


### PR DESCRIPTION
In current Ogre these are actually typedef's and compilers complain about an incongruent forward-declaration.

Also, there is no reason not to include the designated header here.