### PR TITLE
add ogre prerequisite header

### DIFF
--- a/rviz_plugin_tutorials/src/imu_display.h
+++ b/rviz_plugin_tutorials/src/imu_display.h
@@ -32,15 +32,11 @@
 
 #ifndef Q_MOC_RUN
 #include <boost/circular_buffer.hpp>
+#include <OgrePrerequisites.h>
 
 #include <rviz/message_filter_display.h>
 #include <sensor_msgs/Imu.h>
 #endif
-
-namespace Ogre
-{
-class SceneNode;
-}
 
 namespace rviz
 {

--- a/rviz_plugin_tutorials/src/imu_visual.h
+++ b/rviz_plugin_tutorials/src/imu_visual.h
@@ -31,12 +31,7 @@
 #define IMU_VISUAL_H
 
 #include <sensor_msgs/Imu.h>
-
-namespace Ogre
-{
-class Vector3;
-class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/rviz_plugin_tutorials/src/plant_flag_tool.h
+++ b/rviz_plugin_tutorials/src/plant_flag_tool.h
@@ -30,12 +30,7 @@
 #define PLANT_FLAG_TOOL_H
 
 #include <rviz/tool.h>
-
-namespace Ogre
-{
-class SceneNode;
-class Vector3;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {


### PR DESCRIPTION
Following the same standard used in https://github.com/ros-visualization/rviz/commit/f9a671bd3f7b248e0543c52dd81e35796a70707c

With this, it is possible to build the system with OGRE 1.12