### PR TITLE
Include class_list_macros.hpp instead of .h

### DIFF
--- a/rviz_plugin_tutorials/src/imu_display.cpp
+++ b/rviz_plugin_tutorials/src/imu_display.cpp
@@ -156,6 +156,6 @@ void ImuDisplay::processMessage( const sensor_msgs::Imu::ConstPtr& msg )
 
 // Tell pluginlib about this class.  It is important to do this in
 // global scope, outside our package's namespace.
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_plugin_tutorials::ImuDisplay,rviz::Display )
 // END_TUTORIAL

--- a/rviz_plugin_tutorials/src/plant_flag_tool.cpp
+++ b/rviz_plugin_tutorials/src/plant_flag_tool.cpp
@@ -288,6 +288,6 @@ void PlantFlagTool::load( const rviz::Config& config )
 
 } // end namespace rviz_plugin_tutorials
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_plugin_tutorials::PlantFlagTool,rviz::Tool )
 // END_TUTORIAL

--- a/rviz_plugin_tutorials/src/teleop_panel.cpp
+++ b/rviz_plugin_tutorials/src/teleop_panel.cpp
@@ -195,6 +195,6 @@ void TeleopPanel::load( const rviz::Config& config )
 // Tell pluginlib about this class.  Every class which should be
 // loadable by pluginlib::ClassLoader must have these two lines
 // compiled in its .cpp file, outside of any namespace scope.
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_plugin_tutorials::TeleopPanel,rviz::Panel )
 // END_TUTORIAL


### PR DESCRIPTION
The .h headers are removed in newer versions of pluginlib-dev